### PR TITLE
Added AlwaysReturnResourceOnCreateUpdate

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
@@ -181,5 +181,13 @@ namespace JsonApiDotNetCore.Configuration
         /// If true, will automatically sort resources by Id, if no other sort was specified. Default is true.
         /// </summary>
         bool EnableDefaultSortById { get; set; }
+
+        /// <summary>
+        /// If true, will return the serialized updated resource on POST 201 Created and PATCH 200 OK. Otherwise, the serialized resource is only returned
+        /// if any field is changed on the server that was not included in the original request. Default is false
+        /// <see href="https://jsonapi.org/format/#crud-updating-responses-200">https://jsonapi.org/format/#crud-updating-responses-200</see>
+        /// <see href="https://jsonapi.org/format/#crud-creating-responses-204">https://jsonapi.org/format/#crud-creating-responses-204</see>
+        /// </summary>
+        bool AlwaysReturnResourceOnCreateUpdate { get; set; }
     }
 }

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -86,6 +86,9 @@ namespace JsonApiDotNetCore.Configuration
         public bool EnableDefaultSortById { get; set; } = true;
 
         /// <inheritdoc />
+        public bool AlwaysReturnResourceOnCreateUpdate { get; set; } = false;
+
+        /// <inheritdoc />
         public JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings
         {
             ContractResolver = new DefaultContractResolver

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -229,7 +229,7 @@ namespace JsonApiDotNetCore.Services
 
             bool hasImplicitChanges = _resourceChangeTracker.HasImplicitChanges();
 
-            if (!hasImplicitChanges)
+            if (!_options.AlwaysReturnResourceOnCreateUpdate && !hasImplicitChanges)
             {
                 return null;
             }
@@ -383,7 +383,7 @@ namespace JsonApiDotNetCore.Services
 
             bool hasImplicitChanges = _resourceChangeTracker.HasImplicitChanges();
 
-            if (!hasImplicitChanges)
+            if (!_options.AlwaysReturnResourceOnCreateUpdate && !hasImplicitChanges)
             {
                 return null;
             }


### PR DESCRIPTION
Added setting to IJsonApiOptions to always return a serialized resource on PATCH and POST, regardless if implicit changes occurred on server.